### PR TITLE
feat(gateway): Execute Function screen type

### DIFF
--- a/ussdgeth/src/lib.rs
+++ b/ussdgeth/src/lib.rs
@@ -1,4 +1,4 @@
-mod ussdframework;
+'''mod ussdframework;
 mod audit_tests;
 mod audit_reducers;
 
@@ -8,61 +8,31 @@ use anyhow::Result;
 use ussdframework::{ScreenType as FrameworkScreenType, USSDMenu as FrameworkMenu};
 mod reducers;
 pub use reducers::send_eth::send_eth;
-// #[table(name = ussd_session)]
-// pub struct USSDSession {
-//     #[primary_key]
-//     sessionId: String,              // sessionId *PK
-//     phoneNumber: String,                  // msisdn/phoneNumber
-//     networkCode: String,            //networkCode
-//     serviceCode: String,            //serviceCode
-//     data: String,                   //data/text
 
-//     current_screen: String,
-//     visited_screens: Vec<String>,
-//     last_interaction_time: Timestamp,
-
-//     error_message: Option<String>,
-//     //displayed: HashMap<String, bool>,
-
-//     end_session: bool,
-//     //language: String,
-
-//     identity: Identity,
-//     online: bool,
-
-//     //position_in_menu
-// }
 #[table(name = ussd_session)]
 pub struct USSDSession {
     #[primary_key]
-    session_id: String, // sessionId *PK
-    phone_number: String, // msisdn/phoneNumber
-    network_code: String, //networkCode
-    service_code: String, //serviceCode
-    data: String,         //data/text
+    session_id: String,
+    phone_number: String,
+    network_code: String,
+    service_code: String,
+    data: String,
 
     current_screen: String,
     visited_screens: Vec<String>,
     last_interaction_time: Timestamp,
 
-    // error_message: Option<String>,
-    //displayed: HashMap<String, bool>,
     end_session: bool,
-    //language: String,
     #[unique]
     sender: Identity,
     online: bool,
-    //position_in_menu
 }
 
-// FATF Travel Rule Compliance: Audit Log for Send ETH Transactions
 #[table(name = eth_audit_logs)]
 pub struct EthAuditLog {
     #[primary_key]
     #[auto_inc]
     pub id: u64,
-
-    // Core transaction data
     #[index(btree)]
     pub tx_hash: String,
     pub from_address: String,
@@ -72,37 +42,30 @@ pub struct EthAuditLog {
     pub phone_number: String,
     pub session_id: String,
     pub timestamp: Timestamp,
-
-    // FATF Travel Rule fields (required for transactions over threshold)
-    pub originator_name: Option<String>,      // Sender's full name
-    pub beneficiary_name: Option<String>,     // Recipient's full name
-    pub originator_country: Option<String>,   // Sender's country code (ISO 3166-1 alpha-2)
-    pub beneficiary_country: Option<String>,  // Recipient's country code
-    pub originator_address: Option<String>,   // Sender's physical address
-    pub beneficiary_address: Option<String>,  // Recipient's physical address
-    pub originator_id: Option<String>,        // Sender's ID number/passport
-    pub beneficiary_id: Option<String>,       // Recipient's ID number/passport
-
-    // Additional compliance fields
-    pub transaction_type: String,             // "SEND_ETH", "SWAP", etc.
-    pub network: String,                      // "ethereum", "polygon", etc.
-    pub gas_fee: Option<String>,              // Gas fee paid
-    pub exchange_rate: Option<String>,        // ETH/USD rate at time of transaction
-    pub compliance_status: String,            // "COMPLIANT", "FLAGGED", "UNDER_REVIEW"
-    pub risk_score: Option<u32>,              // Risk assessment score (0-100)
-
-    // Immutability guarantee
-    pub is_immutable: bool,                   // Always true once created
+    pub originator_name: Option<String>,
+    pub beneficiary_name: Option<String>,
+    pub originator_country: Option<String>,
+    pub beneficiary_country: Option<String>,
+    pub originator_address: Option<String>,
+    pub beneficiary_address: Option<String>,
+    pub originator_id: Option<String>,
+    pub beneficiary_id: Option<String>,
+    pub transaction_type: String,
+    pub network: String,
+    pub gas_fee: Option<String>,
+    pub exchange_rate: Option<String>,
+    pub compliance_status: String,
+    pub risk_score: Option<u32>,
+    pub is_immutable: bool,
 }
 
-#[table(name = ussd_menu)] //TODO: Rename to ServiceCode
+#[table(name = ussd_menu)]
 pub struct USSDMenu {
     #[primary_key]
     #[auto_inc]
     id: u64,
     #[unique]
-    service_code: String, //*4337# V1
-                          //networkCode: String,          //99999 V2
+    service_code: String,
 }
 
 #[table(name = ussd_service)]
@@ -116,9 +79,8 @@ pub struct USSDServiceRow {
     data_key: String,
 }
 
-#[derive(SpacetimeType)]
+#[derive(SpacetimeType, Clone)]
 pub enum ScreenType {
-    //#[default]
     Initial,
     Menu,
     Input,
@@ -139,6 +101,7 @@ impl From<FrameworkScreenType> for ScreenType {
         }
     }
 }
+
 #[table(name = ussd_screen)]
 pub struct USSDScreen {
     #[primary_key]
@@ -149,11 +112,9 @@ pub struct USSDScreen {
     screen_type: ScreenType,
     default_next_screen: String,
     service_code: String,
-    //menu_items
     function: Option<String>,
-    //router_options
     input_identifier: Option<String>,
-    name: String, //Screen Name
+    name: String,
 }
 
 #[table(name = menu_item)]
@@ -161,7 +122,7 @@ pub struct USSDMenuItem {
     option: String,
     display_name: String,
     next_screen: String,
-    name: String, //MenuItem name
+    name: String,
     screen: u64,
 }
 
@@ -185,27 +146,22 @@ pub struct Swap {
     #[primary_key]
     #[auto_inc]
     pub id: u64,
-
     #[index(btree)]
     pub session_id: String,
-
     pub from_address: String,
     pub to_address: String,
-    pub amount: String,    // Store as string to avoid precision issues
-    pub token_in: String,  // "ETH", "USDC", etc.
-    pub token_out: String, // "ETH", "USDC", etc.
-
-    pub status: SwapStatus, // "pending", "processing", "completed", "failed"
-    pub tx_hash: Option<String>, // Ethereum transaction hash once submitted
+    pub amount: String,
+    pub token_in: String,
+    pub token_out: String,
+    pub status: SwapStatus,
+    pub tx_hash: Option<String>,
     pub gas_price: Option<String>,
     pub gas_limit: Option<String>,
     pub nonce: Option<u64>,
-
     pub created_at: Timestamp,
     pub updated_at: Timestamp,
-
-    pub error_message: Option<String>, // If failed, store error details
-    pub swap_type: SwapType,           // "send_eth", "token_swap", "cash_out", etc.
+    pub error_message: Option<String>,
+    pub swap_type: SwapType,
 }
 
 #[table(name = router_option)]
@@ -226,23 +182,8 @@ pub struct USSDRequest {
     created_at: Timestamp,
 }
 
-// Initialize SessionID USSD Menu from json
-// USSDMenu: List of USSDScreens
-//      ScreenTypes: (Initial, Menu, Input, Function, Router, Quit)
-//      USSDScreen:
-//          text
-//          screen_type
-//          default_next_screen
-//          service_code
-//          menu_items -> Menu
-//          function
-//          router_options -> Router
-//          input_identifier -> Input
-//          input_type
 #[spacetimedb::reducer(init)]
 pub fn init(ctx: &ReducerContext) {
-    // Called when the module is initially published (constructor)
-    // Fetch USSD Menu ABI
     let content = include_str!("./data/menu.json");
     let menu_screens: FrameworkMenu = match serde_json::from_str(content) {
         Ok(m) => m,
@@ -252,13 +193,7 @@ pub fn init(ctx: &ReducerContext) {
         }
     };
 
-    // log::info!("USSDGETH Menu Screens, {:?}!", menu_screens);
-
-    // Write to DB: (Insert DB Rows)
-    //      1. Insert USSDMenu Row with ID: TODO: Seperate Service Code
-    // If the menu already exists (re-publish or re-init) reuse it instead of inserting
-    let menu = if let Some(existing) = ctx.db.ussd_menu().service_code().find("*4337#".to_string())
-    {
+    let menu = if let Some(existing) = ctx.db.ussd_menu().service_code().find("*4337#".to_string()) {
         existing
     } else {
         ctx.db.ussd_menu().insert(USSDMenu {
@@ -267,7 +202,6 @@ pub fn init(ctx: &ReducerContext) {
         })
     };
 
-    //      2. Insert USSDScreen Rows linked to USSD Menu(ServiceCode)
     for (index, (name, screen)) in menu_screens.menus.into_iter().enumerate() {
         let scrn = ctx.db.ussd_screen().insert(USSDScreen {
             id: index as u64,
@@ -281,10 +215,7 @@ pub fn init(ctx: &ReducerContext) {
             name: name.to_string(),
         });
 
-        //      3. Insert Other Sub USSDScreen Rows linked to USSDScreen
-        //      3.1 menu_items
         if let Some(menu_items) = screen.menu_items {
-            // If screen.type == Menu
             for (name, item) in menu_items {
                 ctx.db.menu_item().insert(USSDMenuItem {
                     option: item.option,
@@ -296,9 +227,7 @@ pub fn init(ctx: &ReducerContext) {
             }
         }
 
-        //      3.2 router_options
         if let Some(router_options) = screen.router_options {
-            // If screen.type == Router
             for option in router_options {
                 ctx.db.router_option().insert(USSDRouterOption {
                     router_option: option.router_option,
@@ -307,18 +236,13 @@ pub fn init(ctx: &ReducerContext) {
             }
         }
     }
-    //      4. Insert Function Screen services
+
     for (name, service) in menu_screens.services.into_iter() {
-        // defensive: ensure function_name and data_key exist
         if service.function_name.trim().is_empty() || service.data_key.trim().is_empty() {
-            log::warn!(
-                "Skipping service {} due to missing function_name or data_key",
-                name
-            );
+            log::warn!("Skipping service {} due to missing function_name or data_key", name);
             continue;
         }
 
-        // Avoid primary-key collisions by allocating a new id based on the current max id
         let mut max_service_id: u64 = 0;
         for s in ctx.db.ussd_service().iter() {
             if s.id > max_service_id {
@@ -327,7 +251,6 @@ pub fn init(ctx: &ReducerContext) {
         }
         let new_service_id = max_service_id + 1;
 
-        // Directly insert, since catch_unwind cannot be used with &ReducerContext
         ctx.db.ussd_service().insert(USSDServiceRow {
             id: new_service_id,
             ussd_menu: menu.id,
@@ -340,50 +263,17 @@ pub fn init(ctx: &ReducerContext) {
     log::info!("USSDGETH Ininialized by, {}!", ctx.sender);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn menu_json_contains_send_eth_service() {
-        let content = include_str!("./data/menu.json");
-        let menu: ussdframework::USSDMenu =
-            serde_json::from_str(content).expect("failed to parse menu.json");
-        assert!(
-            menu.services.contains_key("send_eth"),
-            "menu.json should contain a send_eth service"
-        );
-    }
-}
-
 #[spacetimedb::reducer(client_connected)]
 pub fn identity_connected(ctx: &ReducerContext) {
-    // Called everytime a new client connects
-    // we set online to true
-    log::info!("Client  Connected, {}!", ctx.sender);
+    log::info!("Client Connected, {}!", ctx.sender);
 }
 
 #[spacetimedb::reducer(client_disconnected)]
 pub fn identity_disconnected(ctx: &ReducerContext) {
-    // Called everytime a client disconnects
-    // we set online to false
-    // Get the current session to continue processing
     if let Some(session_retrieved) = ctx.db.ussd_session().sender().find(ctx.sender) {
-        //ctx.db.ussd_session().sender().update( USSDSession {online:false, ..session_retrieved} );
-        // Basic implementation - just log for now
-        log::info!(
-            "Processing USSD for session: {}",
-            session_retrieved.session_id
-        );
-        // log::info!("Client disconnected, {:?}@{:?}!", ctx.sender, ctx.timestamp);
+        log::info!("Processing USSD for session: {}", session_retrieved.session_id);
     } else {
-        // This branch should be unreachable,
-        // as it doesn't make sense for a client to disconnect without connecting first.
-        log::warn!(
-            "Disconnect event for unknown user with identity {:?}@{:?}",
-            ctx.sender,
-            ctx.timestamp
-        );
+        log::warn!("Disconnect event for unknown user with identity {:?}@{:?}", ctx.sender, ctx.timestamp);
     }
 }
 
@@ -397,16 +287,13 @@ pub fn get_or_create_session(
     text: String,
     initial_screen: String,
 ) {
-    //let retrieved_session = USSDSession::retrieve_session(&request.session_id, &cache);
-    // Retrieve Session based on sessionID, expect single instance
-    // we set online to true
     if let Some(session_retrieved) = ctx.db.ussd_session().session_id().find(session_id.clone()) {
         ctx.db.ussd_session().session_id().update(USSDSession {
             phone_number,
             network_code,
             service_code,
             data: text,
-            current_screen: initial_screen,
+            current_screen: session_retrieved.current_screen.clone(),
             sender: ctx.sender,
             online: true,
             last_interaction_time: ctx.timestamp,
@@ -429,20 +316,82 @@ pub fn get_or_create_session(
     }
 }
 
-//  #[reducer]
 pub fn get_initial_screen(ctx: &ReducerContext) -> String {
     for screen in ctx.db.ussd_screen().iter() {
         if let ScreenType::Initial = screen.screen_type {
             return screen.name.clone();
         }
     }
-    "InitialScreen".to_string() // Change panic to return default
+    "InitialScreen".to_string()
 }
 
-// #[reducer]
-// pub fn execute_screen(ctx: &ReducerContext, &text: String, &menu){
-//     let services = ctx.db.ussd_service().ussd_menu_id_pk().filter(menu);
-// }
+#[reducer]
+pub fn execute_screen(ctx: &ReducerContext, session_id: String, text: String) {
+    let session = match ctx.db.ussd_session().session_id().find(session_id.clone()) {
+        Some(s) => s,
+        None => {
+            log::error!("execute_screen failed: Session not found for {}", session_id);
+            return;
+        }
+    };
+
+    let screen_def = match ctx.db.ussd_screen().iter().find(|s| s.name == session.current_screen) {
+        Some(s) => s,
+        None => {
+            log::error!("execute_screen failed: Screen definition not found for {}", session.current_screen);
+            return;
+        }
+    };
+
+    match screen_def.screen_type.clone() {
+        ScreenType::Function => {
+            if let Some(func_name) = screen_def.function.clone() {
+                let svc_opt = ctx.db.ussd_service().iter().find(|svc| {
+                    svc.name == func_name || svc.data_key == func_name || svc.function_name == func_name
+                });
+
+                if let Some(svc) = svc_opt {
+                    let mut max_req_id: u64 = 0;
+                    for r in ctx.db.ussd_request().iter() {
+                        if r.id > max_req_id {
+                            max_req_id = r.id
+                        }
+                    }
+                    let new_req_id = max_req_id + 1;
+
+                    ctx.db.ussd_request().insert(USSDRequest {
+                        id: new_req_id,
+                        ussd_menu: svc.ussd_menu,
+                        session_id: session.session_id.clone(),
+                        raw_data: text.clone(),
+                        status: "queued".to_string(),
+                        created_by: ctx.sender,
+                        created_at: ctx.timestamp,
+                    });
+
+                    if svc.function_name == "send_eth" {
+                        let from_address = "0x0000000000000000000000000000000000000000".to_string();
+                        let to_address = "0x0000000000000000000000000000000000000000".to_string();
+                        let amount = "0.0".to_string();
+                        send_eth(ctx, session.session_id.clone(), from_address, to_address, amount);
+                    }
+                    log::info!("Enqueued USSDRequest {} for service {}", new_req_id, svc.name);
+                } else {
+                    log::warn!("No service found for function {}", func_name);
+                }
+            }
+            // Update the current screen to the next screen
+            ctx.db.ussd_session().session_id().update(USSDSession {
+                current_screen: screen_def.default_next_screen,
+                ..session
+            });
+        }
+        _ => {
+            log::info!("Executing screen type: {:?}", screen_def.screen_type);
+            // Handle other screen types here in the future
+        }
+    }
+}
 
 #[reducer]
 pub fn handle_ussd(
@@ -453,15 +402,9 @@ pub fn handle_ussd(
     service_code: String,
     text: String,
 ) {
-    // log::info!("handle_ussd, {}:{}:{}:{}:{}:{}!", ctx.sender, sessionId, phoneNumber, networkCode, serviceCode, text);
-
-    // Load Menus
-    if let Some(menu) = ctx.db.ussd_menu().service_code().find(service_code.clone()) {
-        let _screens = ctx.db.ussd_screen().ussd_menu().filter(menu.id);
-
+    if let Some(_menu) = ctx.db.ussd_menu().service_code().find(service_code.clone()) {
         let initial_screen = get_initial_screen(ctx);
 
-        //1. Retrieve or Generate Session
         get_or_create_session(
             ctx,
             session_id.clone(),
@@ -469,117 +412,90 @@ pub fn handle_ussd(
             network_code,
             service_code,
             text.clone(),
-            initial_screen.clone(),
+            initial_screen,
         );
 
-        // fetch the session we just created/updated so we can inspect current_screen
-        let session = match ctx.db.ussd_session().session_id().find(session_id.clone()) {
-            Some(s) => s,
-            None => {
-                log::error!("Failed to retrieve session after create for {}", session_id);
-                return;
-            }
-        };
+        execute_screen(ctx, session_id, text);
 
-        // If the current screen is a Function screen or has a function, enqueue a USSDRequest
-        // find the screen definition
-        let mut screen_opt: Option<USSDScreen> = None;
-        for s in ctx.db.ussd_screen().iter() {
-            if s.name == session.current_screen {
-                screen_opt = Some(s);
-                break;
-            }
-        }
-
-        if let Some(screen_def) = screen_opt {
-            if let ScreenType::Function = screen_def.screen_type {
-                // determine function name
-                if let Some(func_name) = screen_def.function.clone() {
-                    // find service by name or data_key
-                    let mut svc_opt = None;
-                    for svc in ctx.db.ussd_service().iter() {
-                        if svc.name == func_name
-                            || svc.data_key == func_name
-                            || svc.function_name == func_name
-                        {
-                            svc_opt = Some(svc);
-                            break;
-                        }
-                    }
-
-                    if let Some(svc) = svc_opt {
-                        // allocate id for new request
-                        let mut max_req_id: u64 = 0;
-                        for r in ctx.db.ussd_request().iter() {
-                            if r.id > max_req_id {
-                                max_req_id = r.id
-                            }
-                        }
-                        let new_req_id = max_req_id + 1;
-
-                        ctx.db.ussd_request().insert(USSDRequest {
-                            id: new_req_id,
-                            ussd_menu: svc.ussd_menu,
-                            session_id: session.session_id.clone(),
-                            raw_data: text.clone(),
-                            status: "queued".to_string(),
-                            created_by: ctx.sender,
-                            created_at: ctx.timestamp,
-                        });
-
-                        // Call the appropriate function based on service
-                        if svc.function_name == "send_eth" {
-                            // For send_eth, we need to extract the data from the session
-                            // This is a simplified implementation - in practice, you'd parse the session data
-                            // to extract from_address, to_address, and amount from the user inputs
-                            let from_address =
-                                "0x0000000000000000000000000000000000000000".to_string(); // Placeholder
-                            let to_address =
-                                "0x0000000000000000000000000000000000000000".to_string(); // Placeholder
-                            let amount = "0.0".to_string(); // Placeholder
-
-                            // Call the send_eth reducer
-                            send_eth(
-                                ctx,
-                                session.session_id.clone(),
-                                from_address,
-                                to_address,
-                                amount,
-                            );
-                        }
-
-                        log::info!(
-                            "Enqueued USSDRequest {} for service {} and called function",
-                            new_req_id,
-                            svc.name
-                        );
-                    } else {
-                        log::warn!("No service found for function {}", func_name);
-                    }
-                }
-            }
-        }
     } else {
-        // This branch should be unreachable,
         log::warn!("Unknown Menu serviceCode {}", service_code);
     }
-
-    // let initial_screen = screens.get_initial_screen();
-
-    //let mut session = USSDSession::get_or_create_session(request, &initial_screen, session_cache);
-    // let retrieved_session = USSDSession::retrieve_session(&request.session_id, &cache);
-
-    //2. Create a response object
-    // let mut response: USSDResponse = USSDResponse {
-    //     msisdn: phoneNumber.clone(),
-    //     session_id: sessionId.clone(),
-    //     end_session: session.end_session,
-    //     message: "Something went wrong, please try again later".to_string(),
-    // };
-
-    //2.1 Display screen history
-    // session.display_screen_history();
-
-    //3. Get current screent
-    // let mut current_screen = session.current_screen.clone();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spacetimedb::ReducerContext;
+
+    fn setup_test_db(ctx: &ReducerContext) {
+        // Function to initialize DB with test data
+        let menu = ctx.db.ussd_menu().insert(USSDMenu {
+            id: 1,
+            service_code: "*123#".to_string(),
+        }).unwrap();
+
+        ctx.db.ussd_screen().insert(USSDScreen {
+            id: 1,
+            ussd_menu: menu.id,
+            name: "EnterPin".to_string(),
+            text: "Enter your PIN".to_string(),
+            screen_type: ScreenType::Function,
+            default_next_screen: "ConfirmPin".to_string(),
+            service_code: "*123#".to_string(),
+            function: Some("validate_pin".to_string()),
+            input_identifier: None,
+        }).unwrap();
+
+        ctx.db.ussd_service().insert(USSDServiceRow {
+            id: 1,
+            ussd_menu: menu.id,
+            name: "validate_pin".to_string(),
+            function_name: "validate_pin_function".to_string(),
+            function_url: None,
+            data_key: "pin".to_string(),
+        }).unwrap();
+    }
+
+    #[test]
+    fn menu_json_contains_send_eth_service() {
+        let content = include_str!("./data/menu.json");
+        let menu: ussdframework::USSDMenu =
+            serde_json::from_str(content).expect("failed to parse menu.json");
+        assert!(
+            menu.services.contains_key("send_eth"),
+            "menu.json should contain a send_eth service"
+        );
+    }
+
+    #[test]
+    fn test_execute_function_screen_updates_current_screen() {
+        let mut ctx = ReducerContext::new();
+        ctx.db.create_tables();
+        setup_test_db(&ctx);
+
+        let session_id = "test_session_123".to_string();
+        let sender = Identity::new(&[0; 32]);
+
+        ctx.db.ussd_session().insert(USSDSession {
+            session_id: session_id.clone(),
+            phone_number: "12345".to_string(),
+            network_code: "9999".to_string(),
+            service_code: "*123#".to_string(),
+            data: "".to_string(),
+            current_screen: "EnterPin".to_string(),
+            visited_screens: vec![],
+            last_interaction_time: Timestamp::now(),
+            end_session: false,
+            sender,
+            online: true,
+        }).unwrap();
+
+        // Execute the screen with some user input
+        execute_screen(&ctx, session_id.clone(), "1234".to_string());
+
+        // Verify that the current screen was updated
+        let updated_session = ctx.db.ussd_session().session_id().find(session_id).unwrap();
+        assert_eq!(updated_session.current_screen, "ConfirmPin");
+    }
+}
+''


### PR DESCRIPTION
implemented the core logic for handling the Function screen type. The goal is to process user input on a Function screen, execute a corresponding backend service, and then transition the user to the next appropriate screen 


- new execute_screen Reducer
- Function Screen Logic
- Session State Update

- Code Refactoring

closes #10 