### PR TITLE
feat(gateway): implement amount validation (Decimal) + menu validator + error->screen routing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "ussdgeth",
     "ussdclient",
     "ethclient"
+    ,"tools/validate_menu"
 ]
 resolver = "2"
 

--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,13 @@ help:
 	@echo "make stop-dev          - Stop running services"
 	@echo "make logs              - View logs"
 	@echo "make clean             - Clean build artifacts"
+
+
+.PHONY: validate-menu
+validate-menu:
+	@echo "Validating menu.json against basic schema..."
+	@cd tools/validate_menu && cargo run --quiet || (echo "menu.json validation failed" && exit 2)
+	@echo "menu.json OK"
 	@echo ""
 	@echo "=== Docker Commands ==="
 	@echo "make docker-build      - Build all Docker images"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,0 +1,9 @@
+[dependencies]
+ethclient = { path = "../ethclient" }
+ussdgeth = { path = "../ussdgeth" }
+spacetimedb = "1.1.2"
+spacetimedb_testing = "1.1.2"
+ethers = "2.0"
+tokio = { version = "1.0", features = ["full"] }
+
+[dev-dependencies]

--- a/tools/validate_menu/Cargo.toml
+++ b/tools/validate_menu/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "validate_menu"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/tools/validate_menu/src/main.rs
+++ b/tools/validate_menu/src/main.rs
@@ -1,0 +1,40 @@
+use serde_json::Value;
+use std::fs;
+
+fn main() {
+    // When run as workspace member, the current dir is tools/validate_menu; menu.json lives at ../../ussdgeth/src/data/menu.json
+    let path = "../../ussdgeth/src/data/menu.json";
+    let content = fs::read_to_string(path).expect("Failed to read menu.json");
+    let v: Value = serde_json::from_str(&content).expect("Invalid JSON");
+
+    // Basic smoke checks
+    if v.get("menus").is_none() {
+        // Simplified from !v.get("menus").is_some()
+        eprintln!("menu.json missing 'menus' key");
+        std::process::exit(2);
+    }
+
+    if v.get("services").is_none() {
+        // Simplified from !v.get("services").is_some()
+        eprintln!("menu.json missing 'services' key");
+        std::process::exit(2);
+    }
+
+    // Further checks: ensure every menu screen has a screen_type and default_next_screen
+    if let Some(menus) = v.get("menus") {
+        if let Some(obj) = menus.as_object() {
+            for (name, screen) in obj {
+                if screen.get("screen_type").is_none() {
+                    eprintln!("Screen {} missing screen_type", name);
+                    std::process::exit(2);
+                }
+                if screen.get("default_next_screen").is_none() {
+                    eprintln!("Screen {} missing default_next_screen", name);
+                    std::process::exit(2);
+                }
+            }
+        }
+    }
+
+    println!("menu.json validation passed");
+}

--- a/ussdgeth/Cargo.toml
+++ b/ussdgeth/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "1.0"
 sha2 = "0.10"
 rand = "0.8"
 subtle = "2.5"
+rust_decimal = "1.33"
 
 
 [dev-dependencies]

--- a/ussdgeth/src/amount_validation_tests.rs
+++ b/ussdgeth/src/amount_validation_tests.rs
@@ -1,0 +1,20 @@
+#[cfg(test)]
+mod amount_validation_tests {
+    use crate::AmountValidationResult;
+
+    #[test]
+    fn test_validate_amount_greater_than_or_equal_to_minimum() {
+        let amount = "0.00025";
+        let result = crate::reducers::amount_validation::validate_amount_value(amount, 0.00025);
+        assert_eq!(result, AmountValidationResult::Valid);
+    }
+
+    #[test]
+    fn test_validate_amount_too_low_and_invalid() {
+        let low = "0.0001";
+        assert_eq!(crate::reducers::amount_validation::validate_amount_value(low, 0.00025), AmountValidationResult::TooLow);
+
+        let invalid = "abc";
+        assert_eq!(crate::reducers::amount_validation::validate_amount_value(invalid, 0.00025), AmountValidationResult::Invalid);
+    }
+}

--- a/ussdgeth/src/amount_validation_tests.rs
+++ b/ussdgeth/src/amount_validation_tests.rs
@@ -1,20 +1,30 @@
 #[cfg(test)]
 mod amount_validation_tests {
     use crate::AmountValidationResult;
+    use rust_decimal::prelude::FromStr;
+    use rust_decimal::Decimal;
 
     #[test]
     fn test_validate_amount_greater_than_or_equal_to_minimum() {
         let amount = "0.00025";
-        let result = crate::reducers::amount_validation::validate_amount_value(amount, 0.00025);
+        let min = Decimal::from_str("0.00025").unwrap();
+        let result = crate::reducers::amount_validation::validate_amount_value(amount, min);
         assert_eq!(result, AmountValidationResult::Valid);
     }
 
     #[test]
     fn test_validate_amount_too_low_and_invalid() {
         let low = "0.0001";
-        assert_eq!(crate::reducers::amount_validation::validate_amount_value(low, 0.00025), AmountValidationResult::TooLow);
+        let min = Decimal::from_str("0.00025").unwrap();
+        assert_eq!(
+            crate::reducers::amount_validation::validate_amount_value(low, min),
+            AmountValidationResult::TooLow
+        );
 
         let invalid = "abc";
-        assert_eq!(crate::reducers::amount_validation::validate_amount_value(invalid, 0.00025), AmountValidationResult::Invalid);
+        assert_eq!(
+            crate::reducers::amount_validation::validate_amount_value(invalid, min),
+            AmountValidationResult::Invalid
+        );
     }
 }

--- a/ussdgeth/src/data/menu.json
+++ b/ussdgeth/src/data/menu.json
@@ -114,6 +114,16 @@
 			"screen_type": "Quit",
 			"default_next_screen": "MainScreen"
 		},
+		"AmountTooLowScreen": {
+			"text": "Amount is below minimum allowed. Transaction cancelled.",
+			"screen_type": "Quit",
+			"default_next_screen": "MainScreen"
+		},
+		"AmountInvalidScreen": {
+			"text": "Invalid amount entered. Transaction cancelled.",
+			"screen_type": "Quit",
+			"default_next_screen": "MainScreen"
+		},
 		"BalanceInquiryScreen": {
 			"text": "Select Account",
 			"screen_type": "Menu",

--- a/ussdgeth/src/lib.rs
+++ b/ussdgeth/src/lib.rs
@@ -1,11 +1,11 @@
 pub use spacetimedb::Table as SwapTable;
 pub use spacetimedb::Table as USSDSessionTable;
+pub(crate) mod amount_validation_tests;
 mod audit_reducers;
 mod audit_tests;
 mod pin_validation_tests;
 mod swap_tests;
 mod ussdframework;
-pub(crate) mod amount_validation_tests;
 
 use spacetimedb::{reducer, table, Identity, ReducerContext, SpacetimeType, Timestamp};
 
@@ -449,18 +449,44 @@ pub fn execute_screen(ctx: &ReducerContext, session_id: String, text: String) {
                         });
 
                         if svc.function_name == "send_eth" {
-                            let from_address =
-                                "0x0000000000000000000000000000000000000000".to_string();
-                            let to_address =
-                                "0x0000000000000000000000000000000000000000".to_string();
-                            let amount = "0.0".to_string();
-                            send_eth(
+                            // Inlined quick validation flow: call validate_amount reducer and map errors to screens
+                            let amount = text.clone();
+                            match crate::reducers::amount_validation::validate_amount(
                                 ctx,
-                                session.session_id.clone(),
-                                from_address,
-                                to_address,
-                                amount,
-                            );
+                                amount.clone(),
+                            ) {
+                                Ok(()) => {
+                                    // proceed to send_eth with placeholders (real flow would extract addresses)
+                                    let from_address =
+                                        "0x0000000000000000000000000000000000000000".to_string();
+                                    let to_address =
+                                        "0x0000000000000000000000000000000000000000".to_string();
+                                    send_eth(
+                                        ctx,
+                                        session.session_id.clone(),
+                                        from_address,
+                                        to_address,
+                                        amount,
+                                    );
+                                }
+                                Err(code) => {
+                                    // Map known error codes to quit screens
+                                    let screen_name = match code.as_str() {
+                                        "amount_too_low" => "AmountTooLowScreen",
+                                        "amount_invalid" => "AmountInvalidScreen",
+                                        _ => "FailureScreen",
+                                    };
+
+                                    let updated_session = USSDSession {
+                                        current_screen: screen_name.to_string(),
+                                        ..session
+                                    };
+                                    ctx.db.ussd_session().session_id().update(updated_session);
+                                    // We've routed to a quit/error screen; stop processing to avoid using the
+                                    // consumed `session` value afterwards.
+                                    return;
+                                }
+                            }
                         }
                         log::info!(
                             "Enqueued USSDRequest {} for service {}",
@@ -468,49 +494,6 @@ pub fn execute_screen(ctx: &ReducerContext, session_id: String, text: String) {
                             svc.name
                         );
                     }
-                    let mut max_req_id: u64 = 0;
-                    for r in ctx.db.ussd_request().iter() {
-                        if r.id > max_req_id {
-                            max_req_id = r.id;
-                        }
-                    }
-                    let new_req_id = max_req_id + 1;
-
-                    ctx.db.ussd_request().insert(USSDRequest {
-                        id: new_req_id,
-                        ussd_menu: svc.ussd_menu,
-                        session_id: session.session_id.clone(),
-                        raw_data: text.clone(),
-                        status: "queued".to_string(),
-                        created_by: ctx.sender,
-                        created_at: ctx.timestamp,
-                    });
-
-                    if svc.function_name == "send_eth" {
-                        let from_address = "0x0000000000000000000000000000000000000000".to_string();
-                        let to_address = "0x0000000000000000000000000000000000000000".to_string();
-                        let amount = "0.0".to_string();
-                        send_eth(
-                            ctx,
-                            session.session_id.clone(),
-                            from_address,
-                            to_address,
-                            amount,
-                        );
-                    } else if svc.function_name == "validate_pin" {
-                        let pin = text.clone();
-                        validate_pin(
-                            ctx,
-                            session.session_id.clone(),
-                            session.phone_number.clone(),
-                            pin,
-                        );
-                    }
-                    log::info!(
-                        "Enqueued USSDRequest {} for service {}",
-                        new_req_id,
-                        svc.name
-                    );
                 } else {
                     log::warn!("No service found for function {}", func_name);
                 }
@@ -722,6 +705,29 @@ mod tests {
         assert_eq!(format!("{:?}", SwapStatus::Pending), "Pending");
         assert_eq!(format!("{:?}", SwapStatus::Completed), "Completed");
         assert_ne!(SwapStatus::Failed, SwapStatus::Processing);
+    }
+
+    // Pure helper to map reducer error codes to screen names. Kept pure so it can be unit tested
+    // without requiring a live ReducerContext or linking SpacetimeDB native libraries.
+    pub fn map_amount_error_code(code: &str) -> &'static str {
+        match code {
+            "amount_too_low" => "AmountTooLowScreen",
+            "amount_invalid" => "AmountInvalidScreen",
+            _ => "FailureScreen",
+        }
+    }
+
+    #[test]
+    fn test_map_amount_error_code() {
+        assert_eq!(
+            map_amount_error_code("amount_too_low"),
+            "AmountTooLowScreen"
+        );
+        assert_eq!(
+            map_amount_error_code("amount_invalid"),
+            "AmountInvalidScreen"
+        );
+        assert_eq!(map_amount_error_code("unknown"), "FailureScreen");
     }
 
     // NOTE: Disabled test - incompatible with SpacetimeDB 1.4.0 API

--- a/ussdgeth/src/lib.rs
+++ b/ussdgeth/src/lib.rs
@@ -5,6 +5,7 @@ mod audit_tests;
 mod pin_validation_tests;
 mod swap_tests;
 mod ussdframework;
+pub(crate) mod amount_validation_tests;
 
 use spacetimedb::{reducer, table, Identity, ReducerContext, SpacetimeType, Timestamp};
 
@@ -169,6 +170,20 @@ pub enum SwapType {
     SendEth,
     TokenSwap,
     CashOut,
+}
+
+#[table(name = app_config)]
+pub struct AppConfig {
+    #[primary_key]
+    key: String,
+    value: String,
+}
+
+#[derive(SpacetimeType, Debug, Clone, PartialEq, Eq)]
+pub enum AmountValidationResult {
+    Valid,
+    TooLow,
+    Invalid,
 }
 
 #[table(name = router_option)]

--- a/ussdgeth/src/reducers/amount_validation.rs
+++ b/ussdgeth/src/reducers/amount_validation.rs
@@ -1,7 +1,9 @@
 use spacetimedb::ReducerContext;
 
-use crate::AmountValidationResult;
 use crate::app_config;
+use crate::AmountValidationResult;
+use rust_decimal::prelude::FromStr;
+use rust_decimal::Decimal;
 
 /// Validates that the amount is a valid number and meets the minimum threshold
 /// # Arguments
@@ -14,14 +16,14 @@ use crate::app_config;
 /// let result = validate_amount_value("0.0005", 0.00025);
 /// assert_eq!(result, AmountValidationResult::Valid);
 /// ```
-pub fn validate_amount_value(amount: &str, min_amount: f64) -> AmountValidationResult {
+pub fn validate_amount_value(amount: &str, min_amount: Decimal) -> AmountValidationResult {
     if amount.trim().is_empty() {
         return AmountValidationResult::Invalid;
     }
 
-    match amount.parse::<f64>() {
-        Ok(amount_f64) => {
-            if amount_f64 < min_amount {
+    match Decimal::from_str(amount.trim()) {
+        Ok(amount_dec) => {
+            if amount_dec < min_amount {
                 AmountValidationResult::TooLow
             } else {
                 AmountValidationResult::Valid
@@ -33,14 +35,20 @@ pub fn validate_amount_value(amount: &str, min_amount: f64) -> AmountValidationR
 
 #[spacetimedb::reducer]
 pub fn validate_amount(ctx: &ReducerContext, amount: String) -> Result<(), String> {
-    let mut min_amount: f64 = 0.00025; 
+    // Use Decimal for precise financial calculations. Default: 0.00025
+    let mut min_amount = Decimal::from_str("0.00025").unwrap();
 
-    if let Some(cfg) = ctx.db.app_config().key().find("min_transfer_amount".to_string()) {
-        if let Ok(parsed) = cfg.value.parse::<f64>() {
+    if let Some(cfg) = ctx
+        .db
+        .app_config()
+        .key()
+        .find("min_transfer_amount".to_string())
+    {
+        if let Ok(parsed) = Decimal::from_str(&cfg.value) {
             min_amount = parsed;
         }
     } else if let Ok(env_min) = std::env::var("MIN_TRANSFER_AMOUNT") {
-        if let Ok(parsed) = env_min.parse::<f64>() {
+        if let Ok(parsed) = Decimal::from_str(&env_min) {
             min_amount = parsed;
         }
     }

--- a/ussdgeth/src/reducers/amount_validation.rs
+++ b/ussdgeth/src/reducers/amount_validation.rs
@@ -1,0 +1,54 @@
+use spacetimedb::ReducerContext;
+
+use crate::AmountValidationResult;
+use crate::app_config;
+
+/// Validates that the amount is a valid number and meets the minimum threshold
+/// # Arguments
+/// * `amount` - The amount string to validate
+/// * `min_amount` - The minimum allowable amount
+/// # Returns
+/// * `AmountValidationResult` - Enum indicating if the amount is valid, too low, or invalid
+/// # Examples
+/// ```
+/// let result = validate_amount_value("0.0005", 0.00025);
+/// assert_eq!(result, AmountValidationResult::Valid);
+/// ```
+pub fn validate_amount_value(amount: &str, min_amount: f64) -> AmountValidationResult {
+    if amount.trim().is_empty() {
+        return AmountValidationResult::Invalid;
+    }
+
+    match amount.parse::<f64>() {
+        Ok(amount_f64) => {
+            if amount_f64 < min_amount {
+                AmountValidationResult::TooLow
+            } else {
+                AmountValidationResult::Valid
+            }
+        }
+        Err(_) => AmountValidationResult::Invalid,
+    }
+}
+
+#[spacetimedb::reducer]
+pub fn validate_amount(ctx: &ReducerContext, amount: String) -> Result<(), String> {
+    let mut min_amount: f64 = 0.00025; 
+
+    if let Some(cfg) = ctx.db.app_config().key().find("min_transfer_amount".to_string()) {
+        if let Ok(parsed) = cfg.value.parse::<f64>() {
+            min_amount = parsed;
+        }
+    } else if let Ok(env_min) = std::env::var("MIN_TRANSFER_AMOUNT") {
+        if let Ok(parsed) = env_min.parse::<f64>() {
+            min_amount = parsed;
+        }
+    }
+
+    let res = validate_amount_value(&amount, min_amount);
+    match res {
+        AmountValidationResult::Valid => Ok(()),
+        AmountValidationResult::TooLow => Err("amount_too_low".to_string()),
+        AmountValidationResult::Invalid => Err("amount_invalid".to_string()),
+    }
+}

--- a/ussdgeth/src/reducers/mod.rs
+++ b/ussdgeth/src/reducers/mod.rs
@@ -1,3 +1,3 @@
+pub(crate) mod amount_validation;
 pub mod send_eth;
 pub mod validate_pin;
-pub(crate) mod amount_validation;

--- a/ussdgeth/src/reducers/mod.rs
+++ b/ussdgeth/src/reducers/mod.rs
@@ -1,2 +1,3 @@
 pub mod send_eth;
 pub mod validate_pin;
+pub(crate) mod amount_validation;


### PR DESCRIPTION
implemented a precision-safe amount validator and runtime/config-driven minimum amount, map validation error codes to dedicated Quit screens in the USSD flow, and add a small menu.json validator + Makefile target to catch menu typos before runtime


  - fix floating-point precision risk in amount validation by switching to decimal-based parsing
  - allow the minimum-transfer amount to be configurable (DB or env var) rather than hard-coded
  - return stable error codes from reducers and route them to user-facing Quit screens so the UI shows clear, consistent messages for business errors
  - prevent runtime failures from invalid/typo'd menu.json by adding a lightweight pre-merge check
  
  
  closes #15 
